### PR TITLE
Correctly handle ProjectileSource being a block

### DIFF
--- a/src/main/java/com/darkender/plugins/accuracy/Accuracy.java
+++ b/src/main/java/com/darkender/plugins/accuracy/Accuracy.java
@@ -1,7 +1,10 @@
 package com.darkender.plugins.accuracy;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Directional;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
@@ -89,10 +92,21 @@ public class Accuracy extends JavaPlugin implements Listener
         }
         else if(source instanceof BlockProjectileSource)
         {
-            // There's a better way to do this for sure
-            // Right now it's comparing the entity's block with the source block to form a normal vector
-            BlockFace face = ((BlockProjectileSource) source).getBlock().getFace(event.getEntity().getLocation().getBlock());
-            fixVelocity(event.getEntity(), OldVersionCompatibility.getBlockFaceDirection(face));
+            Block sourceBlock = ((BlockProjectileSource) source).getBlock();
+            BlockData sourceBlockData = sourceBlock.getBlockData();
+            if(sourceBlockData instanceof Directional)
+            {
+                Directional d = (Directional)sourceBlockData;
+                fixVelocity(event.getEntity(), OldVersionCompatibility.getBlockFaceDirection(d.getFacing()));
+            }
+            else
+            {
+                Block eventBlock = event.getEntity().getLocation().getBlock();
+                BlockFace face = sourceBlock.getFace(eventBlock);
+                Vector direction =  OldVersionCompatibility.getBlockFaceDirection(face);
+                if(direction != null)
+                    fixVelocity(event.getEntity(), direction);
+            }
         }
     }
     


### PR DESCRIPTION
Its way better to get the current block's facing direction than comparing the location of the entity with the block and determining the face, this is mainly because some projectiles start inside the source block itself, causing the face to be SELF and returning null on the direction and failing. I still decided to leave  the old code just as a fallback in case the block is not a directional